### PR TITLE
fix : 엔티티에서 매핑된 테이블명 오타 수정 및 일부 엔티티의 필드 수정

### DIFF
--- a/be/src/main/java/com/project/popupmarket/entity/PopupStore.java
+++ b/be/src/main/java/com/project/popupmarket/entity/PopupStore.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @Entity
-@Table(name = "pppup_store")
+@Table(name = "popup_store")
 public class PopupStore {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/src/main/java/com/project/popupmarket/entity/StagingPayment.java
+++ b/be/src/main/java/com/project/popupmarket/entity/StagingPayment.java
@@ -16,10 +16,10 @@ public class StagingPayment {
     @Id
     @Column(name = "order_id", nullable = false)
     private String orderId;
-    @Column(name = "popup_user_seq", nullable = false)
-    private Long popupUserSeq;
-    @Column(name = "rental_place_seq", nullable = false)
-    private Long rentalPlaceSeq;
+    @Column(name = "customer_id", nullable = false)
+    private Long customerId;
+    @Column(name = "rental_land_id", nullable = false)
+    private Long rentalLandId;
     @Column(name = "start_date", nullable = false)
     private LocalDate startDate;
     @Column(name = "end_date", nullable = false)


### PR DESCRIPTION
- PopupStore 엔티티 'pppup_store' -> 'popup_store'로 수정
- StagingPayment 엔티티의 일부 필드 명칭 변경에 대해서 미반영된 명칭 수정
