### PR TITLE
feat: S3와 연동 및 이미지 업로드 및 조회, 삭제

### DIFF
--- a/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
@@ -63,4 +63,32 @@ public class ImageController {
     }
 
 
+    @GetMapping("/images/single")
+    public ResponseEntity<String> getSingleImage(
+            @RequestParam("category") String category,
+            @RequestParam("userId") Long userId,
+            @RequestParam("categoryId") Long categoryId
+    ) {
+        try {
+            String imageUrl = s3FileService.getSingleImage(category, userId, categoryId);
+            return ResponseEntity.ok(imageUrl);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(404).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/images/multiple")
+    public ResponseEntity<List<String>> getMultipleImages(
+            @RequestParam("category") String category,
+            @RequestParam("userId") Long userId,
+            @RequestParam("categoryId") Long categoryId
+    ) {
+        List<String> imageUrls = s3FileService.getMultipleImages(category, userId, categoryId);
+        if (imageUrls.isEmpty()) {
+            return ResponseEntity.status(404).body(List.of("No multiple images found for userId: " + userId));
+        }
+        return ResponseEntity.ok(imageUrls);
+    }
+
+
 }

--- a/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
@@ -90,5 +90,20 @@ public class ImageController {
         return ResponseEntity.ok(imageUrls);
     }
 
+        @DeleteMapping("/delete")
+    public ResponseEntity<List<String>> deleteFiles(
+            @RequestParam("category") String category,
+            @RequestParam("userId") Long userId,
+            @RequestParam("categoryId") Long categoryId
+    ) {
+        List<String> deletedKeys = s3FileService.deleteFiles(category, userId, categoryId);
+
+        if (deletedKeys.isEmpty()) {
+            return ResponseEntity.status(404).body(List.of("No files found for category: " + category + " and userId: " + userId));
+        }
+
+        return ResponseEntity.ok(deletedKeys);
+    }
+
 
 }

--- a/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
@@ -26,5 +26,11 @@ public class ImageController {
         }
     }
 
+    @GetMapping("/images")
+    public ResponseEntity<List<String>> getAllImageUrls() {
+        List<String> imageUrls = s3FileService.getAllImageUrls();
+        return ResponseEntity.ok(imageUrls);
+    }
+
 
 }

--- a/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
@@ -1,0 +1,30 @@
+package com.project.popupmarket.controller.Image;
+
+import com.project.popupmarket.service.aws.S3FileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class ImageController {
+    @Autowired
+    S3FileService s3FileService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadImage(@RequestParam("file") MultipartFile file) {
+        try {
+            String url = s3FileService.uploadImage(file);
+            return ResponseEntity.ok(url);
+        } catch (IOException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to upload image");
+        }
+    }
+
+
+}

--- a/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
+++ b/be/src/main/java/com/project/popupmarket/controller/Image/ImageController.java
@@ -26,6 +26,36 @@ public class ImageController {
         }
     }
 
+    @PostMapping("/single")
+    public ResponseEntity<String> uploadSingleImage(
+            @RequestParam("image") MultipartFile image,
+            @RequestParam("category") String category,
+            @RequestParam("userId") Long userId,
+            @RequestParam("categoryId") Long categoryId
+    ) {
+        try {
+            String imageUrl = s3FileService.uploadSingleImage(image, userId, categoryId, category);
+            return ResponseEntity.ok(imageUrl);
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body("Image upload failed: " + e.getMessage());
+        }
+    }
+
+    @PostMapping("/multiple")
+    public ResponseEntity<List<String>> uploadMultipleImages(
+            @RequestParam("images") List<MultipartFile> images,
+            @RequestParam("category") String category,
+            @RequestParam("userId") Long userId,
+            @RequestParam("categoryId") Long categoryId
+    ) {
+        try {
+            List<String> imageUrls = s3FileService.uploadMultipleImages(images, userId, categoryId, category);
+            return ResponseEntity.ok(imageUrls);
+        } catch (IOException e) {
+            return ResponseEntity.status(500).body(List.of("Image upload failed: " + e.getMessage()));
+        }
+    }
+
     @GetMapping("/images")
     public ResponseEntity<List<String>> getAllImageUrls() {
         List<String> imageUrls = s3FileService.getAllImageUrls();

--- a/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
+++ b/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
@@ -107,6 +107,40 @@ public class S3FileService {
                 .collect(Collectors.toList());
     }
 
+    public String getSingleImage(String category, Long userId, Long categoryId) {
+        String prefix = String.format("%s/%d_%d_thumbnail_", category, userId, categoryId);
+
+        ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(prefix)
+                .build();
+
+        ListObjectsV2Response response = s3Client.listObjectsV2(request);
+
+        return response.contents().stream()
+                .findFirst()
+                .map(S3Object::key)
+                .map(this::getImageUrl)
+                .orElseThrow(() -> new RuntimeException("No single image found for userId: " + userId));
+    }
+
+    public List<String> getMultipleImages(String category, Long userId, Long categoryId) {
+        String prefix = String.format("%s/%d_%d_images_", category, categoryId, userId);
+
+        ListObjectsV2Request request = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(prefix)
+                .build();
+
+        ListObjectsV2Response response = s3Client.listObjectsV2(request);
+
+        // URL 리스트 생성
+        return response.contents().stream()
+                .map(S3Object::key)
+                .map(this::getImageUrl)
+                .collect(Collectors.toList());
+    }
+
     private String getImageUrl(String fileName) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
     }

--- a/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
+++ b/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
@@ -51,6 +51,21 @@ public class S3FileService {
         return getImageUrl(fileName);
     }
 
+    public List<String> getAllImageUrls() {
+        // S3 버킷의 모든 객체 목록 가져오기
+        ListObjectsV2Request listObjectsRequest = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .build();
+
+        ListObjectsV2Response listObjectsResponse = s3Client.listObjectsV2(listObjectsRequest);
+
+        // 객체 키로부터 URL 생성
+        return listObjectsResponse.contents().stream()
+                .map(S3Object::key)
+                .map(this::getImageUrl)
+                .collect(Collectors.toList());
+    }
+
     private String getImageUrl(String fileName) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
     }

--- a/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
+++ b/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
@@ -3,8 +3,20 @@ package com.project.popupmarket.service.aws;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,5 +28,30 @@ public class S3FileService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    // 여기부터 메소드 작성하세요.
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public String uploadImage(MultipartFile image) throws IOException {
+        // 파일 이름 생성
+        String fileName = UUID.randomUUID() + "_" + image.getOriginalFilename();
+
+        // S3에 파일 업로드 요청 생성
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(image.getContentType())
+                .build();
+
+        // S3에 파일 업로드
+        PutObjectResponse response = s3Client.putObject(
+                putObjectRequest,
+                RequestBody.fromInputStream(image.getInputStream(), image.getSize())
+        );
+
+        return getImageUrl(fileName);
+    }
+
+    private String getImageUrl(String fileName) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
+    }
 }

--- a/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
+++ b/be/src/main/java/com/project/popupmarket/service/aws/S3FileService.java
@@ -141,6 +141,32 @@ public class S3FileService {
                 .collect(Collectors.toList());
     }
 
+    public List<String> deleteFiles(String category, Long userId, Long categoryId) {
+        String prefix = String.format("%s/%d_%d_", category, userId,categoryId);
+
+        ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(prefix)
+                .build();
+
+        ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
+
+        List<String> keysToDelete = listResponse.contents().stream()
+                .map(S3Object::key)
+                .collect(Collectors.toList());
+
+        // S3에서 각 파일 삭제
+        keysToDelete.forEach(key -> {
+            DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+            s3Client.deleteObject(deleteRequest);
+        });
+
+        return keysToDelete;
+    }
+
     private String getImageUrl(String fileName) {
         return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
     }


### PR DESCRIPTION
## 1. 이미지 업로드 기능
- S3 연결 설정
- 이미지 업로드 컨트롤러 및 서비스 구현
  - 단일 업로드 API (`/single`)
  - 다중 업로드 API (`/multiple`)
- 업로드 파일명 규칙 적용
  - 단일 파일: `category/userId_categoryId_thumbnail_파일명`
  - 다중 파일: `category/userId_categoryId_images_파일번호_파일명`

## 2. S3 모든 이미지 조회 기능
- 모든 이미지 데이터를 반환하는 컨트롤러 (`/images`) 추가
- S3 객체 목록을 가져오는 서비스 구현

## 3. 단일 및 다중 이미지 조회 기능
- 단일 이미지 조회 API (`/images/single`) 추가
  - 파라미터: `category`, `userId`, `categoryId`
  - 파일명 형식: `category/userId_categoryId_thumbnail_`
- 다중 이미지 조회 API (`/images/multiple`) 추가
  - 파라미터: `category`, `userId`, `categoryId`
  - 파일명 형식: `category/userId_categoryId_images_`
- 단일 및 다중 이미지 조회를 처리하는 서비스 구현
  - S3 URL 반환
  
## 4. 이미지 삭제 기능
- 이미지 삭제 컨트롤러 및 서비스 구현
  - 삭제 API (`/delete`) 추가
  - 파라미터: `category`, `userId`, `categoryId`
  - 삭제 대상 파일 경로: `category/userId_categoryId_`로 시작하는 이미지 파일